### PR TITLE
fix: properly update servers menu item when the context is changed

### DIFF
--- a/frontend/src/components/common/MenuItem/TMenuItem.vue
+++ b/frontend/src/components/common/MenuItem/TMenuItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-link v-if="isItemVisible" :to="route" active-class="item__active">
+  <router-link :to="route" active-class="item__active">
     <div class="item">
       <t-icon class="item__icon" :icon="icon" />
       <p class="item__name">{{ name }}</p>
@@ -25,7 +25,6 @@ export default {
       type: String,
       required: true,
     },
-    isItemVisible: Boolean,
   },
 };
 </script>

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -126,28 +126,3 @@ export const getUpgradeID = async () => {
     ? ctx.cluster.uid
     : null || contextName || response?.currentContext;
 }
-
-export const checkIsSidero = async (context) => {
-  
-  const checkCRD = async (id: string) => {
-    try {
-      await ResourceService.Get({
-        type: kubernetes.crd,
-        id: id,
-      }, {
-        context:context
-      });
-
-      return true;
-    } catch(e:any) {
-      if(e.code !== Code.NOT_FOUND)
-        throw e;
-
-      return false;
-    }
-  }
-  const sidero = checkCRD("servers.metal.sidero.dev");
-  const hasSidero = await sidero;
-  
-  return hasSidero;
-}

--- a/frontend/src/views/Overview/Overview.vue
+++ b/frontend/src/views/Overview/Overview.vue
@@ -28,6 +28,7 @@ import { ManagementService } from "@/api/grpc";
 import { onMounted } from "@vue/runtime-core";
 import TWatch from "@/components/common/Watch/TWatch.vue";
 import { getUpgradeID } from "@/methods";
+
 export default {
   components: {
     TOverviewContent,

--- a/frontend/src/views/Overview/components/TOverviewContent.vue
+++ b/frontend/src/views/Overview/components/TOverviewContent.vue
@@ -55,7 +55,7 @@
             :resource="{
               type: talos.cpu,
               namespace: talos.perfNamespace,
-              tail_events: 25,
+              tail_events: 2,
             }"
             :context="context"
             @cpu="(data) => getDataFromNode(data)"
@@ -309,6 +309,7 @@ export default {
         return b.cpu - a.cpu;
       });
     };
+
     const getDataFromNode = (data) => {
       nodesItems.value![data.index].cpu = +data.cpu;
     };


### PR DESCRIPTION
Also, remove unnecessary complexity from the Overview page which was
pulled from the charts component.
Keep track only of the last point and don't support several series. Also
limit the amount of points we request to the minumum value.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>