### PR TITLE
fix: get rid of racy code in the kubeconfig request code

### DIFF
--- a/internal/backend/runtime/kubernetes/kubernetes.go
+++ b/internal/backend/runtime/kubernetes/kubernetes.go
@@ -262,8 +262,8 @@ func (r *Runtime) GetKubeconfig(ctx context.Context, context *common.Context) (*
 			return nil, err
 		}
 
-		r.configsMu.RLock()
-		defer r.configsMu.RUnlock()
+		r.configsMu.Lock()
+		defer r.configsMu.Unlock()
 
 		r.configs[id] = config
 


### PR DESCRIPTION
RLock was used in the write operation.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>