### PR TITLE
fix: remove t-header error notification

### DIFF
--- a/frontend/src/components/THeader/THeader.vue
+++ b/frontend/src/components/THeader/THeader.vue
@@ -5,6 +5,7 @@
     :context="context"
     :recordsNotificationStatus="false"
     :isSpinnerActive="false"
+    :errorNotificationStatus="false"
   >
     <template #default="items">
       <header class="theHeader">


### PR DESCRIPTION
Removed error notification from THeader component.

Signed-off-by: evgeniybryzh<evgeniy@merge.rocks>