### PR TITLE
chore: allow getting resources without version and group

### DIFF
--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -71,15 +71,13 @@ export const encodeProtobuf = (type?: string, spec?: any) => {
   return res.encode(res.fromPartial(spec)).finish();
 }
 
-const capiVersion = "v1alpha4"
-
 export const kubernetes = {
   service: "services.v1",
   pod: "pods.v1",
   node: "nodes.v1",
-  cluster: `clusters.${capiVersion}.cluster.x-k8s.io`,
-  machine: `machines.${capiVersion}.cluster.x-k8s.io`,
-  sideroServers: "servers.v1alpha1.metal.sidero.dev",
+  cluster: `clusters`,
+  machine: `machines`,
+  sideroServers: "servers",
   crd: "customresourcedefinitions.v1.apiextensions.k8s.io",
 };
 


### PR DESCRIPTION
That should help to keep Theila backward and forward compatible with
any CRDs from CAPI or whatever else.

Now if the resource name is represented only with a single word without
any dots in it, the backend will look up version and group by using the
discovery service. Same way as it is done by kubectl.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>